### PR TITLE
Speed up parse-int

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict'
 
 var isInteger = require('is-integer')
+var isIntegerRegex = /^-?\d+$/
 
 module.exports = function parseIntStrict (integer) {
   if (typeof integer === 'number') {
     return isInteger(integer) ? integer : undefined
   }
   if (typeof integer === 'string') {
-    return /^-?\d+$/.test(integer) ? parseInt(integer, 10) : undefined
+    return isIntegerRegex.test(integer) ? parseInt(integer, 10) : undefined
   }
 }


### PR DESCRIPTION
 - [x] Moved regex outside the parse function. This speed up parsing for ~11%(on my computer).

Source
https://jsperf.com/is-integer-perf